### PR TITLE
Make `Ringtoneservice` a Foreground Service.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,6 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.AlarmQ">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <application

--- a/app/src/main/java/srihk/alarmq/AlarmQ.kt
+++ b/app/src/main/java/srihk/alarmq/AlarmQ.kt
@@ -35,7 +35,11 @@ class AlarmQ : BroadcastReceiver() {
             }
         }
 
-        context?.startService(ringtoneServiceIntent) /* Start Alarm */
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context?.startForegroundService(ringtoneServiceIntent)
+        } else {
+            context?.startService(ringtoneServiceIntent)
+        } /* Start Alarm */
     }
 
     fun setAlarm(context: Context, minutes: Int) {

--- a/app/src/main/java/srihk/alarmq/Constants.kt
+++ b/app/src/main/java/srihk/alarmq/Constants.kt
@@ -6,4 +6,5 @@ object Constants {
     const val SNOOZE = "SNOOZE"
     const val STOP = "STOP"
     const val ACTION = "ACTION"
+    const val NOTIFICATION_ID = 1
 }

--- a/app/src/main/java/srihk/alarmq/MainActivity.kt
+++ b/app/src/main/java/srihk/alarmq/MainActivity.kt
@@ -1,6 +1,9 @@
 package srihk.alarmq
 
+import android.Manifest
 import android.content.SharedPreferences
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
@@ -53,17 +56,25 @@ class MainActivity : ComponentActivity(), SharedPreferences.OnSharedPreferenceCh
                             ).show()
                         }
                         else {
-                            if (isRunning.value) { /* Stop */
-                                alarmQ.removeAlarm(this)
-                            } else { /* Start */
-                                alarmQ.setAlarm(
-                                    this,
-                                    snoozeList[0]
-                                )
+                            if (
+                                Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                                checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) ==
+                                PackageManager.PERMISSION_DENIED
+                            ) {
+                                requestPermissions(arrayOf(Manifest.permission.POST_NOTIFICATIONS),0)
+                            } else {
+                                if (isRunning.value) { /* Stop */
+                                    alarmQ.removeAlarm(this)
+                                } else { /* Start */
+                                    alarmQ.setAlarm(
+                                        this,
+                                        snoozeList[0]
+                                    )
+                                }
+                                isRunning.value = !isRunning.value
+                                setIsRunning(this, isRunning = isRunning.value)
+                                setState(this, 0)
                             }
-                            isRunning.value = !isRunning.value
-                            setIsRunning(this, isRunning = isRunning.value)
-                            setState(this, 0)
                         }
                     }
                 )

--- a/app/src/main/java/srihk/alarmq/Preferences.kt
+++ b/app/src/main/java/srihk/alarmq/Preferences.kt
@@ -23,7 +23,7 @@ object Preferences {
         val s = prefs.getString(KEY_SNOOZE_LIST, "")
         val list = mutableListOf<Int>()
         if (s != null && s.isNotEmpty()) {
-            for (elem in s.split(" ").toList()) {
+            for (elem in s.split(" ")) {
                 list.add(elem.toInt())
             }
         }

--- a/app/src/main/java/srihk/alarmq/RingtoneService.kt
+++ b/app/src/main/java/srihk/alarmq/RingtoneService.kt
@@ -1,5 +1,6 @@
 package srihk.alarmq
 
+import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
@@ -12,10 +13,10 @@ import android.os.Build
 import android.os.IBinder
 import android.widget.Toast
 import androidx.core.app.NotificationCompat
+import srihk.alarmq.Constants.NOTIFICATION_ID
 
 class RingtoneService : Service() {
     private var alarmRingtone: Ringtone? = null
-    private var notificationManager: NotificationManager? = null
 
     override fun onBind(intent: Intent?): IBinder? {
         return null
@@ -38,7 +39,7 @@ class RingtoneService : Service() {
             // TODO: Facilitate the user to set default alarm.
         }
 
-        notificationManager = this.getSystemService(NOTIFICATION_SERVICE)
+        val notificationManager: NotificationManager = this.getSystemService(NOTIFICATION_SERVICE)
                 as NotificationManager
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -47,25 +48,24 @@ class RingtoneService : Service() {
                 Constants.NOTIFICATION_CHANNEL_NAME,
                 NotificationManager.IMPORTANCE_HIGH
             )
-            notificationManager?.createNotificationChannel(channel)
+            notificationManager.createNotificationChannel(channel)
         }
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Toast.makeText(this, "Alarm Ringing!", Toast.LENGTH_SHORT).show()
         alarmRingtone?.play()
-        sendNotification(this)
+        startForeground(NOTIFICATION_ID, buildNotification(this))
         return START_STICKY
     }
 
     override fun onDestroy() {
         alarmRingtone?.stop()
-        notificationManager?.cancel(0)
         Toast.makeText(this, "Alarm Stopped", Toast.LENGTH_SHORT).show()
         super.onDestroy()
     }
 
-    private fun sendNotification(context: Context) {
+    private fun buildNotification(context: Context): Notification {
         val snoozeIntent = Intent(context, AlarmQ::class.java).putExtra(
             Constants.ACTION,
             Constants.SNOOZE
@@ -106,6 +106,6 @@ class RingtoneService : Service() {
             .setPriority(NotificationCompat.PRIORITY_MAX)
             .setOngoing(true)
 
-        notificationManager?.notify(0, builder.build())
+        return builder.build()
     }
 }


### PR DESCRIPTION
# Changes

- `RingtoneService`: Make `RingtoneService` a Foreground Service.
- `Preferences`: Remove a superfluous `toList()` call.
- `AndroidManifest`: Remove a redundant label highlighted in a warning.
- `MainActivity`: Request user for `POST_NOTIFICATIONS` permission on Android 13 when the user taps on start button.